### PR TITLE
Actual over budget highlight, big decimal refactor

### DIFF
--- a/app/src/main/java/com/budget/app/controller/MainController.java
+++ b/app/src/main/java/com/budget/app/controller/MainController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -71,11 +72,11 @@ public class MainController {
 				List<Transaction> relatedTransactions = budgetService.getTransactionsByLineItemId(item);
 				if (relatedTransactions.isEmpty())
 				{
-					item.setCumulativeActualAmount(BigDecimal.valueOf(0.00));
+					item.setCumulativeActualAmount(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
 				}
 				else
 				{
-					BigDecimal accumulatedActualAmount = BigDecimal.valueOf(0.00);
+					BigDecimal accumulatedActualAmount = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
 					for (Transaction transact : relatedTransactions)
 					{
 						accumulatedActualAmount = accumulatedActualAmount.add(transact.getActualAmount());

--- a/app/src/main/java/com/budget/app/entity/LineItem.java
+++ b/app/src/main/java/com/budget/app/entity/LineItem.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +24,8 @@ public class LineItem
     private String lineItemName; // Example: "Electric Bill", "Paycheck"
 
     @Column(name="planned_amount")
-    private BigDecimal plannedAmount = BigDecimal.valueOf(0.00); // Example: 100.50
+    private BigDecimal plannedAmount = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    //BigDecimal.valueOf(0.00); // Example: 100.50
 
     @Column(name="is_income")
     private boolean isIncome; // True for income, False for expenses

--- a/app/src/main/java/com/budget/app/entity/Transaction.java
+++ b/app/src/main/java/com/budget/app/entity/Transaction.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Date;
 
 @Entity
@@ -22,7 +23,8 @@ public class Transaction
     private String merchant;
 
     @Column(name="actual_amount")
-    private BigDecimal actualAmount = BigDecimal.valueOf(0.00);
+    private BigDecimal actualAmount = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    // BigDecimal.valueof(0.00);
 
     @Column(name = "transaction_date")
     private Date transactionDate;

--- a/app/src/main/java/com/budget/app/service/BudgetServiceImplementation.java
+++ b/app/src/main/java/com/budget/app/service/BudgetServiceImplementation.java
@@ -42,6 +42,26 @@ public class BudgetServiceImplementation implements BudgetService
         return userRepository.findByEmailAddress(email);
     }
 
+//    @Override
+//    public List<BudgetDate> getBudgetDatesBetween(LocalDate currentDate)
+//    {
+//        BudgetDate budgetDate = budgetDateRepository.findByBudgetDateBetween(currentDate);
+//        Integer currentBudgetDateId = budgetDate.getId();
+//        List<Integer> ids = new ArrayList<Integer>();
+//
+//        // TO DO need to write a more flexible algorithm here.
+//        // This assumes 5 months to display and that the 3 month "march" is the current and selected month.
+//        ids.add(currentBudgetDateId - 2);
+//        ids.add(currentBudgetDateId - 1);
+//        ids.add(currentBudgetDateId);
+//        ids.add(currentBudgetDateId + 1);
+//        ids.add(currentBudgetDateId + 2);
+//        List<BudgetDate> listBudgetDates = budgetDateRepository.findByIdIn(ids);
+//        listBudgetDates.get(2).setCurrentBudgetMonth(true);
+//        listBudgetDates.get(2).setBudgetSelected(true);
+//        return listBudgetDates;
+//    }
+
     @Override
     public List<BudgetDate> getBudgetDatesBetween(LocalDate currentDate)
     {

--- a/app/src/main/resources/templates/dashboardFragments.html
+++ b/app/src/main/resources/templates/dashboardFragments.html
@@ -39,11 +39,10 @@
                 <tr th:each="lineItem : ${category.getLineItems()}">
                     <td th:text="${lineItem.lineItemName}"></td>
                     <td>
-                        <span>$</span>
-                        <span th:text="${lineItem.plannedAmount}"></span>
+                        <span th:text="'$'+${lineItem.plannedAmount}"></span>
                     </td>
-                    <td>
-                        <span>$</span><span th:text="${lineItem.getCumulativeActualAmount()}"></span>
+                    <td th:class="${lineItem.plannedAmount < lineItem.cumulativeActualAmount}?text-danger">
+                        <span th:text="${lineItem.plannedAmount < lineItem.cumulativeActualAmount}?'$'+${lineItem.cumulativeActualAmount}+' (over budget)':'$'+${lineItem.cumulativeActualAmount}"></span>
                     </td>
                     <td class="tableWidth">
                         <form th:action="@{/updateLineItem}" method="post">


### PR DESCRIPTION
https://trello.com/c/lV8EqHlL/42-line-item-actual-amount-red-when-over-planned-amount

Added a conditional on the actual budget field to highlight red and show (over budget) if the transaction actual amount is more than the planned amount.

Refactored the planned and actual amount entity and main controller population to use BigDecimale.ZERO.SetScale(2, RoundingMode.HALF_UP) rather the .valueOf(0.00). The previous approach ended up displaying 0.0 on the table and transaction form rather then 0.00.

Other little thing: removed the space between $ amount using '$' escape sequence on the table actual and planned amounts.

![image](https://github.com/user-attachments/assets/4331b44a-cf74-49c0-b139-3175603e1f70)

![image](https://github.com/user-attachments/assets/a9a0a620-2fae-4067-963d-67f3add1fecf)
