### PR TITLE
updated data.sql with budget ID 4 for April

### DIFF
--- a/app/src/main/java/com/budget/app/entity/BudgetDate.java
+++ b/app/src/main/java/com/budget/app/entity/BudgetDate.java
@@ -88,4 +88,18 @@ public class BudgetDate
     public void setCurrentBudgetMonth(boolean currentBudgetMonth) {this.currentBudgetMonth = currentBudgetMonth;}
 
     public void setBudgetSelected(boolean budgetSelected) {this.budgetSelected = budgetSelected;}
+
+    @Override
+    public String toString() {
+        return "BudgetDate{" +
+                "id=" + id +
+                ", budgetYear=" + budgetYear +
+                ", budgetMonth='" + budgetMonth + '\'' +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", budgets=" + budgets +
+                ", currentBudgetMonth=" + currentBudgetMonth +
+                ", budgetSelected=" + budgetSelected +
+                '}';
+    }
 }

--- a/app/src/main/resources/data.sql
+++ b/app/src/main/resources/data.sql
@@ -41,19 +41,19 @@ VALUES (2025, 'Dec', '2025-12-01', '2025-12-31');
 
 -- Budget (budget_id autoincrement to 1 (josh))
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 1);
+VALUES (4, 1);
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 2);
+VALUES (4, 2);
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 3);
+VALUES (4, 3);
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 4);
+VALUES (4, 4);
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 5);
+VALUES (4, 5);
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 6);
+VALUES (4, 6);
 INSERT INTO budgets (date_id, user_id)
-VALUES (3, 7);
+VALUES (4, 7);
 
 -- Josh (1)
 INSERT INTO categories (category_name, budget_id)


### PR DESCRIPTION
The test data created budget IDs 3 (March). We're now in April, so the blank state page shows to add a budget in the current month. Modified our data.sql to Budget ID 4 so the dashboard loads by default instead.