### PR TITLE
bank integration with plaid

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -72,6 +72,11 @@
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.plaid</groupId>
+			<artifactId>plaid-java</artifactId>
+			<version>30.1.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/app/src/main/java/com/budget/app/AppConfig.java
+++ b/app/src/main/java/com/budget/app/AppConfig.java
@@ -1,5 +1,6 @@
 package com.budget.app;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,4 +15,19 @@ public class AppConfig
 
     @Bean
     public DateTimeFormatter customFormatter() { return DateTimeFormatter.ofPattern("yyyy-MM-dd"); }
+//
+//    @Value("${plaid_client_id}")
+//    public String plaidClientId;
+//
+//    @Value("${plaid_secret}")
+//    public String plaidSecret;
+//
+//    @Value("${plaid_products}")
+//    public String plaidProducts;
+//
+//    @Value("${plaid_country_codes}")
+//    public String plaidCountryCodes;
+//
+//    @Value("${plaid_env}")
+//    public String plaidEnv;
 }

--- a/app/src/main/java/com/budget/app/controller/MainController.java
+++ b/app/src/main/java/com/budget/app/controller/MainController.java
@@ -2,6 +2,7 @@ package com.budget.app.controller;
 
 import com.budget.app.domain.ExtractParameter;
 import com.budget.app.entity.*;
+import com.budget.app.entity.plaid.PlaidBankAccount;
 import com.budget.app.security.model.CustomUserDetails;
 import com.budget.app.service.BudgetService;
 import com.budget.app.service.CategoryService;
@@ -149,6 +150,9 @@ public class MainController {
 
 			List<Transaction> transactions = budgetService.getTransactions(lineItems);
 			model.addAttribute("transactions", transactions);
+
+			List<PlaidBankAccount> banks = budgetService.getBanksByUserId(currentUser);
+			model.addAttribute("banks", banks);
 
 			List<String> labels = new ArrayList<>();
 			List<Double> transactionValues = new ArrayList<>();

--- a/app/src/main/java/com/budget/app/controller/PlaidController.java
+++ b/app/src/main/java/com/budget/app/controller/PlaidController.java
@@ -1,0 +1,183 @@
+package com.budget.app.controller;
+
+import com.budget.app.entity.User;
+import com.budget.app.entity.plaid.PlaidAccessTokens;
+import com.budget.app.entity.plaid.PlaidBankAccount;
+import com.budget.app.security.model.CustomUserDetails;
+import com.budget.app.service.BudgetService;
+import com.plaid.client.ApiClient;
+import com.plaid.client.model.*;
+import com.plaid.client.request.PlaidApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/plaid")
+public class PlaidController
+{
+    @Value("${plaid.client.id}")
+    private String plaidClientId;
+
+    @Value("${plaid.secret}")
+    private String plaidSecret;
+
+    @Autowired
+    private BudgetService budgetService;
+
+
+    @GetMapping("/link-token")
+    public ResponseEntity<?> getLinkToken() throws IOException
+    {
+//        System.out.println("Plaid Client Id: " + plaidClientId);
+//        System.out.println("Plaid Secret: " + plaidSecret);
+
+        // Set up Plaid client
+        HashMap<String, String> apiKeys = new HashMap<>();
+        apiKeys.put("clientId", plaidClientId);
+        apiKeys.put("secret", plaidSecret);
+
+        ApiClient apiClient = new ApiClient(apiKeys);
+        apiClient.setPlaidAdapter(ApiClient.Sandbox);
+        PlaidApi plaidClient = apiClient.createService(PlaidApi.class);
+
+        // Get current authenticated user
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        User currentUser = userDetails.getUser();
+        String clientUserId = String.valueOf(currentUser.getId());
+
+        // Build request
+        LinkTokenCreateRequest request = new LinkTokenCreateRequest()
+                .user(new LinkTokenCreateRequestUser().clientUserId(clientUserId))
+                .clientName("Budget App")
+                .products(Arrays.asList(Products.AUTH, Products.TRANSACTIONS))
+                .countryCodes(Arrays.asList(CountryCode.US))
+                .language("en");
+
+        // Execute request
+        Response<LinkTokenCreateResponse> response = plaidClient.linkTokenCreate(request).execute();
+
+        if (response.isSuccessful())
+        {
+            // EXCLUDES other unused response body fields 'expiration', 'requestId', 'hostedLinkUrl'
+            Map<String, String> tokenMap = new HashMap<>();
+            tokenMap.put("link_token", response.body().getLinkToken());
+            return ResponseEntity.ok(tokenMap);
+            // return ResponseEntity.ok(response.body());
+        }
+        else
+        {
+            return ResponseEntity.status(500).body("Failed to create link token: " + response.errorBody().string());
+        }
+    }
+
+//    @CrossOrigin(origins = "http://localhost:8080", allowCredentials = "true")
+    @PostMapping("/public-token-exchange")
+    public ResponseEntity<?> publicTokenExchange(@RequestParam("public_token") String publicToken) throws IOException
+    {
+        // Set up Plaid client
+        HashMap<String, String> apiKeys = new HashMap<>();
+        apiKeys.put("clientId", plaidClientId);
+        apiKeys.put("secret", plaidSecret);
+
+        ApiClient apiClient = new ApiClient(apiKeys);
+        apiClient.setPlaidAdapter(ApiClient.Sandbox);
+        PlaidApi plaidClient = apiClient.createService(PlaidApi.class);
+
+        // Get current authenticated user
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        User currentUser = userDetails.getUser();
+
+        // Build request
+        ItemPublicTokenExchangeRequest request = new ItemPublicTokenExchangeRequest()
+                .publicToken(publicToken);
+
+        // Execute request
+        Response<ItemPublicTokenExchangeResponse> response = plaidClient.itemPublicTokenExchange(request).execute();
+
+        budgetService.updateOrInsertPlaidAccess(response.body().getAccessToken(),
+                                                response.body().getItemId(),
+                                                response.body().getRequestId(),
+                                                currentUser);
+
+        if (response.isSuccessful())
+        {
+            System.out.println("Public to persistent access token successful: " + response.body().toString());
+            return ResponseEntity.status(200).body("Public to persistent access token successful: " + response.body().toString());
+        }
+        else
+        {
+            System.out.println("Failed to exchange public for persistent token: " + response.errorBody().string());
+            return ResponseEntity.status(500).body("Failed to exchange public for persistent oken: " + response.errorBody().string());
+        }
+    }
+
+    @GetMapping("accounts-balance")
+    public ResponseEntity<?> accountsBalance() throws IOException
+    {
+        // Set up Plaid client
+        HashMap<String, String> apiKeys = new HashMap<>();
+        apiKeys.put("clientId", plaidClientId);
+        apiKeys.put("secret", plaidSecret);
+
+        ApiClient apiClient = new ApiClient(apiKeys);
+        apiClient.setPlaidAdapter(ApiClient.Sandbox);
+        PlaidApi plaidClient = apiClient.createService(PlaidApi.class);
+
+        // Get current authenticated user
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        User currentUser = userDetails.getUser();
+
+        //PlaidAccessTokens plaidAccessTokens = budgetService.getPlaidAccessToken(currentUser);
+
+        // Build request
+        AccountsBalanceGetRequest request = new AccountsBalanceGetRequest()
+                .accessToken(budgetService.getPlaidAccessToken(currentUser).getAccessToken());
+                        //plaidAccessTokens.getAccessToken());
+
+        // Execute request
+        Response<AccountsGetResponse> response = plaidClient.accountsBalanceGet(request).execute();
+
+        // PARSE THROUGH THE RESPONSE
+        // STORE THE DATA IN THE Plaid Bank Account entity table.
+        if (response.isSuccessful())
+        {
+            // This assumes there is an account retrieved, and that there is only one account and is has a subtype defined.
+            // TO DO null checking
+            // TO DO flexibility for more than 1 account found / connected.
+            String accountId = response.body().getAccounts().get(0).getAccountId();
+            Double balanceAvailable = response.body().getAccounts().get(0).getBalances().getAvailable();
+            Double balanceCurrent = response.body().getAccounts().get(0).getBalances().getCurrent();
+            String accountName = response.body().getAccounts().get(0).getName();
+            String accountNameOfficial = response.body().getAccounts().get(0).getOfficialName();
+            String subtype = response.body().getAccounts().get(0).getSubtype().getValue();
+            String institution = response.body().getItem().getInstitutionName();
+
+            PlaidBankAccount plaidBankAccount = new PlaidBankAccount(accountId, balanceAvailable, balanceCurrent,
+                    accountName, accountNameOfficial, subtype,
+                    institution, currentUser);
+
+            budgetService.updateOrInsertPlaidBankAccount(plaidBankAccount);
+
+            System.out.println("Accounts balance get request was successful: " + response.body().toString());
+            return ResponseEntity.status(200).body("Accounts balance get request was successful: " + response.body().toString());
+        }
+        else
+        {
+            System.out.println("Failed to get account balances: " + response.errorBody().string());
+            return ResponseEntity.status(500).body("Failed to get account balances: " + response.errorBody().string());
+        }
+    }
+}

--- a/app/src/main/java/com/budget/app/entity/User.java
+++ b/app/src/main/java/com/budget/app/entity/User.java
@@ -1,5 +1,7 @@
 package com.budget.app.entity;
 
+import com.budget.app.entity.plaid.PlaidAccessTokens;
+import com.budget.app.entity.plaid.PlaidBankAccount;
 import jakarta.persistence.*;
 import org.springframework.stereotype.Component;
 
@@ -39,6 +41,11 @@ public class User
     //@OneToOne(mappedBy = "user")
     private List<Budget> budgets = new ArrayList<Budget>();
 
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    private List<PlaidAccessTokens> plaidAccessTokens = new ArrayList<PlaidAccessTokens>();
+
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    private List<PlaidBankAccount> plaidBankAccounts = new ArrayList<PlaidBankAccount>();
 
     // Constructors
     public User() {}
@@ -113,4 +120,8 @@ public class User
     public List<Budget> getBudgets() {return budgets;}
 
     public void setBudgets(List<Budget> budgets) {this.budgets = budgets;}
+
+    public List<PlaidAccessTokens> getPlaidAccessTokens() {return plaidAccessTokens;}
+
+    public void setPlaidAccessTokens(List<PlaidAccessTokens> plaidAccessTokens) { this.plaidAccessTokens = plaidAccessTokens; }
 }

--- a/app/src/main/java/com/budget/app/entity/plaid/PlaidAccessTokens.java
+++ b/app/src/main/java/com/budget/app/entity/plaid/PlaidAccessTokens.java
@@ -1,0 +1,56 @@
+package com.budget.app.entity.plaid;
+
+import com.budget.app.entity.User;
+import jakarta.persistence.*;
+
+@Entity
+public class PlaidAccessTokens
+{
+    // Database Setup
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plaid_access_id")
+    private int id;
+
+    @Column(name = "access_token")
+    private String accessToken;
+
+    @Column(name = "item_id")
+    private String itemId;
+
+    @Column(name = "request_id")
+    private String requestId;
+
+    // Connections
+    @ManyToOne(cascade = {CascadeType.DETACH,CascadeType.MERGE,CascadeType.REFRESH})
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public PlaidAccessTokens() {}
+    public PlaidAccessTokens(String accessToken, String itemId, String requestId, User user) {
+        this.accessToken = accessToken;
+        this.itemId = itemId;
+        this.requestId = requestId;
+        this.user = user;
+    }
+
+    public int getId() {return id;}
+
+    public String getAccessToken() {return accessToken;}
+
+    public String getItemId() {return itemId;}
+
+    public String getRequestId() {return requestId;}
+
+    public User getUser() {return user;}
+
+    public void setId(int id) { this.id = id; }
+
+    public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
+
+    public void setItemId(String itemId) { this.itemId = itemId; }
+
+    public void setRequestId(String requestId) { this.requestId = requestId; }
+
+    public void setUser(User user) { this.user = user; }
+}

--- a/app/src/main/java/com/budget/app/entity/plaid/PlaidBankAccount.java
+++ b/app/src/main/java/com/budget/app/entity/plaid/PlaidBankAccount.java
@@ -1,0 +1,133 @@
+package com.budget.app.entity.plaid;
+
+import com.budget.app.entity.User;
+import jakarta.persistence.*;
+
+@Entity
+public class PlaidBankAccount
+{
+    // Database Setup
+    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bank_account_id")
+    private String id;
+
+    @Column(name = "balance_available")
+    private Double balanceAvailable;
+
+    @Column(name = "balance_current")
+    private Double balanceCurrent;
+
+    @Column(name = "name")
+    private String accountName;
+
+    @Column(name = "name_official")
+    private String accountNameOfficial;
+
+    @Column(name = "subtype")
+    private String subtype;
+
+    @Column(name = "institution")
+    private String institution;
+
+    // Connections
+    @ManyToOne(cascade = {CascadeType.DETACH,CascadeType.MERGE,CascadeType.REFRESH})
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public PlaidBankAccount() {}
+    public PlaidBankAccount(String id, Double balanceAvailable, Double balanceCurrent, String accountName, String accountNameOfficial, String subtype, String institution, User user) {
+        this.id = id;
+        this.balanceAvailable = balanceAvailable;
+        this.balanceCurrent = balanceCurrent;
+        this.accountName = accountName;
+        this.accountNameOfficial = accountNameOfficial;
+        this.subtype = subtype;
+        this.institution = institution;
+        this.user = user;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Double getBalanceAvailable() {
+        return balanceAvailable;
+    }
+
+    public Double getBalanceCurrent() {
+        return balanceCurrent;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public String getAccountNameOfficial() {
+        return accountNameOfficial;
+    }
+
+    public String getSubtype() {
+        return subtype;
+    }
+
+    public String getInstitution() {
+        return institution;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setBalanceAvailable(Double balanceAvailable) {
+        this.balanceAvailable = balanceAvailable;
+    }
+
+    public void setAccountName(String accountName) {
+        this.accountName = accountName;
+    }
+
+    public void setBalanceCurrent(Double balanceCurrent) {
+        this.balanceCurrent = balanceCurrent;
+    }
+
+    public void setAccountNameOfficial(String accountNameOfficial) {
+        this.accountNameOfficial = accountNameOfficial;
+    }
+
+    public void setSubtype(String subtype) {
+        this.subtype = subtype;
+    }
+
+    public void setInstitution(String institution) {
+        this.institution = institution;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    //    SAMPLE DATA FROM https://sandbox.plaid.com/accounts/balance/get
+//    {
+//        "accounts": [
+//        {
+//            "account_id": "VBE1qonrgWCrq3L9PK6zCQWPzkpAB7UqrJdEA",
+//                "balances": {
+//            "available": 100,
+//                    "current": 110,
+//        },
+//            "name": "Plaid Checking",
+//                "official_name": "Plaid Gold Standard 0% Interest Checking",
+//                "subtype": "checking",
+//        }
+//    ],
+//        "item": {
+//        "institution_name": "Chase",
+//    }
+
+
+}

--- a/app/src/main/java/com/budget/app/repository/PlaidAccessTokensRepository.java
+++ b/app/src/main/java/com/budget/app/repository/PlaidAccessTokensRepository.java
@@ -1,0 +1,13 @@
+package com.budget.app.repository;
+
+import com.budget.app.entity.Transaction;
+import com.budget.app.entity.plaid.PlaidAccessTokens;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaidAccessTokensRepository extends JpaRepository<PlaidAccessTokens, Integer> {
+    default PlaidAccessTokens updateOrInsert(PlaidAccessTokens plaidAccessToken){return save(plaidAccessToken);}
+
+    PlaidAccessTokens getByUserId(int id);
+}

--- a/app/src/main/java/com/budget/app/repository/PlaidBankAccountRepository.java
+++ b/app/src/main/java/com/budget/app/repository/PlaidBankAccountRepository.java
@@ -1,0 +1,14 @@
+package com.budget.app.repository;
+
+import com.budget.app.entity.plaid.PlaidBankAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PlaidBankAccountRepository extends JpaRepository<PlaidBankAccount, Integer> {
+    default PlaidBankAccount updateOrInsert(PlaidBankAccount plaidBankAccount){return save(plaidBankAccount);}
+
+    List<PlaidBankAccount> getByUserId(int id);
+}

--- a/app/src/main/java/com/budget/app/service/BudgetService.java
+++ b/app/src/main/java/com/budget/app/service/BudgetService.java
@@ -1,6 +1,8 @@
 package com.budget.app.service;
 
 import com.budget.app.entity.*;
+import com.budget.app.entity.plaid.PlaidAccessTokens;
+import com.budget.app.entity.plaid.PlaidBankAccount;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,5 +25,9 @@ public interface BudgetService
     public Budget getBudgetByBudgetDateAndUser(User currentUser, BudgetDate budgetDate);
     public Budget getBudgetByBudgetId(int budgetId);
     public void addBudgetPredetermined(User currentUser, BudgetDate budgetDate);
+    public void updateOrInsertPlaidAccess(String accessToken, String itemId, String requestId, User currentUser);
+    public PlaidAccessTokens getPlaidAccessToken(User currentUser);
+    public void updateOrInsertPlaidBankAccount(PlaidBankAccount plaidBankAccount);
+    public List<PlaidBankAccount> getBanksByUserId(User currentUser);
     // calculateBudgetSummary(Int budgetId);
 }

--- a/app/src/main/java/com/budget/app/service/BudgetServiceImplementation.java
+++ b/app/src/main/java/com/budget/app/service/BudgetServiceImplementation.java
@@ -1,6 +1,8 @@
 package com.budget.app.service;
 
 import com.budget.app.entity.*;
+import com.budget.app.entity.plaid.PlaidAccessTokens;
+import com.budget.app.entity.plaid.PlaidBankAccount;
 import com.budget.app.repository.*;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,10 @@ public class BudgetServiceImplementation implements BudgetService
     private LineItemRepository lineItemRepository;
     @Autowired
     private TransactionRepository transactionRepository;
+    @Autowired
+    private PlaidAccessTokensRepository plaidAccessTokensRepository;
+    @Autowired
+    private PlaidBankAccountRepository plaidBankAccountRepository;
 
 
     // Interface Method Implementations
@@ -230,6 +236,29 @@ public class BudgetServiceImplementation implements BudgetService
         LineItem subscriptions = new LineItem("Subscriptions",BigDecimal.valueOf(100.00),false,entertainment,RecurrenceType.MONTHLY);
         List<LineItem> newLineItems = new ArrayList<LineItem>(Arrays.asList(paycheck,rent,insurance,groceries,restaurants,travel,subscriptions));
         lineItemRepository.saveAll(newLineItems);
+    }
+
+    @Override
+    public void updateOrInsertPlaidAccess(String accessToken, String itemId, String requestId, User currentUser)
+    {
+        PlaidAccessTokens plaidAccessToken = new PlaidAccessTokens(accessToken, itemId, requestId, currentUser);
+        PlaidAccessTokens saveResult = plaidAccessTokensRepository.updateOrInsert(plaidAccessToken);
+    }
+
+    @Override
+    public PlaidAccessTokens getPlaidAccessToken(User currentUser) {
+        return plaidAccessTokensRepository.getByUserId(currentUser.getId());
+    }
+
+    @Override
+    public void updateOrInsertPlaidBankAccount(PlaidBankAccount plaidBankAccount)
+    {
+        PlaidBankAccount saveResult = plaidBankAccountRepository.updateOrInsert(plaidBankAccount);
+    }
+
+    @Override
+    public List<PlaidBankAccount> getBanksByUserId(User currentUser) {
+        return plaidBankAccountRepository.getByUserId(currentUser.getId());
     }
 
     // ------------------TO DO-------------------

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -41,3 +41,11 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 spring.thymeleaf.mode=HTML
+plaid.client.id=67fa978450901000234595f7
+#DON'T PUSH WITH THIS VALUE INCLUDED - Only insert locally. Go to the team folder to add this.
+plaid.secret=
+plaid.products=transactions,auth
+plaid.country.codes:US
+plaid.env=sandbox
+#plaid_redirect_uri: ${PLAID_REDIRECT_URI:-""}
+logging.level.org.springframework.security.web.csrf=DEBUG

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -81,6 +81,68 @@
 <div class="div-container container"
      th:replace="dashboardFragments :: ${isBudgetCreatedInCurrentMonth == 'YES'} ? 'actionMenu' : 'nothing'">
 </div>
+<!--Plaid Bank Integration-->
+<!--token: 'link-sandbox-f7b60565-b909-42d7-93dc-8d5d49faa609',-->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+<script type="text/javascript">
+    (async function($) {
+        const response = await fetch('/plaid/link-token');
+        if (!response.ok) throw new Error("Failed to fetch link token");
+        const data = await response.json();
+        console.log('link token response data is:' + data);
+        console.log("Keys in data:", Object.keys(data));
+        const linkToken = data.link_token;
+        console.log('linkToken is:' + linkToken);
+
+        const handler = Plaid.create({
+            token: linkToken,
+            onSuccess: (public_token, metadata) => {
+                console.log('onSuccess');
+                console.log('Public Token: ', public_token);
+                console.log('Metadata: ', metadata);
+                const csrfToken = calculateValue();
+                console.log('csrf', csrfToken);
+                $.ajax({
+                    type: 'POST',
+                    url: '/plaid/public-token-exchange',
+                    data: { public_token: public_token },
+                    xhrFields: {
+                        withCredentials: true
+                    },
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken);
+                    },
+                    success: function(response) {
+                        console.log('Public token exchanged successfully:', response);
+
+                        // Now that the token is exchanged and stored, safely call accounts-balance
+                        $.ajax({
+                            type: 'GET',
+                            url: '/plaid/accounts-balance',
+                            success: function(balanceResponse) {
+                                console.log('Accounts balance:', balanceResponse);
+                                window.location.reload();
+                            },
+                            error: function(xhr, status, error) {
+                                console.error('Failed to get account balances:', error);
+                            }
+                    });
+                    },
+                });
+            },
+            onLoad: () => {console.log('onLoad')},
+            onExit: (err, metadata) => {console.log('onExit')},
+            onEvent: (eventName, metadata) => {console.log('onEvent')},
+    });
+
+    $('#link-button').on('click', function(e) {
+        handler.open();
+        console.log('Plaid Link Button Clicked');
+    });
+
+    })(jQuery);
+</script>
 </body>
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>

--- a/app/src/main/resources/templates/dashboardFragments.html
+++ b/app/src/main/resources/templates/dashboardFragments.html
@@ -121,20 +121,23 @@
     <div class="col-4 transactionColor">
         <ul class="nav nav-tabs nav-justified mt-2">
             <li class="nav-item">
-                <a class="nav-link" id="summary-tab" data-bs-toggle="tab" href="#summary" role="tab" aria-controls="summary" aria-selected="true">Summary</a>
+                <a class="nav-link active" id="summary-tab" data-bs-toggle="tab" href="#summary" role="tab" aria-controls="summary" aria-selected="true">Summary</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link active" id="transaction-tab" data-bs-toggle="tab" aria-current="page" href="#transactions" role="tab" aria-controls="transactions" aria-selected="false">Transactions</a>
+                <a class="nav-link" id="transaction-tab" data-bs-toggle="tab" href="#transactions" role="tab" aria-controls="transactions" aria-selected="false">Transactions</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" id="bank-tab" data-bs-toggle="tab" href="#banks" role="tab" aria-controls="bank" aria-selected="false">Banks</a>
             </li>
         </ul>
         <div class="tab-content mt-2">
-            <div class="tab-pane fade" id="summary" role="tabpanel" aria-labelledby="summary-tab">
+            <div class="tab-pane fade show active" id="summary" role="tabpanel" aria-labelledby="summary-tab">
                 <ul class="nav nav-tabs nav-justified mt-2" id="chartTab" role="tablist">
                     <li class="nav-item">
-                        <a class="nav-link active" id="transactionGraph-tab" data-bs-toggle="tab" href="#transactionGraph" role="tab" aria-controls="transactionGraph" aria-selected="false">Actual</a>
+                        <a class="nav-link" id="transactionGraph-tab" data-bs-toggle="tab" href="#transactionGraph" role="tab" aria-controls="transactionGraph" aria-selected="false">Actual</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="plannedGraph-tab" data-bs-toggle="tab" href="#plannedGraph" role="tab" aria-controls="plannedGraph" aria-selected="true">Planned</a>
+                        <a class="nav-link active" id="plannedGraph-tab" data-bs-toggle="tab" href="#plannedGraph" role="tab" aria-controls="plannedGraph" aria-selected="true">Planned</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" id="remainingGraph-tab" data-bs-toggle="tab" href="#remainingGraph" role="tab" aria-controls="remainingGraph" aria-selected="false">Remaining</a>
@@ -156,7 +159,7 @@
                             </ul>
                         </div>
                     </div>
-                    <div class="tab-pane fade" id="plannedGraph" role="tabpanel" aria-labelledby="plannedGraph-tab">
+                    <div class="tab-pane fade show active" id="plannedGraph" role="tabpanel" aria-labelledby="plannedGraph-tab">
                         <div class="graphContainer text-center">
                             <canvas id="planned"></canvas>
                         </div>
@@ -286,25 +289,60 @@
                     }
                 });
             </script>
-        <div class="tab-pane fade show active" id="transactions" role="tabpanel" aria-labelledby="transactions-tab">
+        <div class="tab-content mt-2">
+            <div class="tab-pane fade" id="transactions" role="tabpanel" aria-labelledby="transactions-tab">
+                <img th:if="${#lists.isEmpty(transactions)}" th:src="@{/images/wallet.png}" alt="transaction wallet" width="100px" style="margin: 0 auto; display: block;" class="mt-3"/>
+                <h4 th:if="${#lists.isEmpty(transactions)}" class="mt-1 mb-1 center">No income or expenses<br>tracked so far this month.</h4>
 
-            <img th:if="${#lists.isEmpty(transactions)}" th:src="@{/images/wallet.png}" alt="transaction wallet" width="100px" style="margin: 0 auto; display: block;" class="mt-3"/>
-            <h4 th:if="${#lists.isEmpty(transactions)}" class="mt-1 mb-1 center">No income or expenses<br>tracked so far this month.</h4>
-
-            <div th:each="transaction: ${transactions}" class="table-container">
-                <div class="row border-bottom border-dark border-1">
-                    <div class="col-4" th:text="${transaction.merchant}"></div>
-                    <div class="col-4" th:text="${transaction.transactionDate}"></div>
-                    <div class="col-4"><span>$</span><span th:text="${transaction.actualAmount}"></span></div>
+                <div th:each="transaction: ${transactions}" class="table-container">
+                    <div class="row border-bottom border-dark border-1">
+                        <div class="col-4" th:text="${transaction.merchant}"></div>
+                        <div class="col-4" th:text="${transaction.transactionDate}"></div>
+                        <div class="col-4"><span>$</span><span th:text="${transaction.actualAmount}"></span></div>
+                    </div>
                 </div>
-            </div>
-            <br>
-            <p style="text-align:center;">Add transactions</p>
+                <br>
+                <p style="text-align:center;">Add transactions</p>
 
-            <!-- Button to trigger transaction modal -->
-            <button type="button" class="btn btn-secondary block marginAuto" data-bs-toggle="modal" data-bs-target="#transactionModal">
-                +
-            </button>
+                <!-- Button to trigger transaction modal -->
+                <button type="button" class="btn btn-secondary block marginAuto" data-bs-toggle="modal" data-bs-target="#transactionModal">
+                    +
+                </button>
+            </div>
+        </div>
+        <div class="tab-content mt-2">
+            <div class="tab-pane fade" id="banks" role="tabpanel" aria-labelledby="banks-tab">
+    <!--            <button id="link-button">Link Account</button>-->
+    <!--            <img th:if="${#lists.isEmpty(transactions)}" th:src="@{/images/wallet.png}" alt="transaction wallet" width="100px" style="margin: 0 auto; display: block;" class="mt-3"/>-->
+    <!--            <h4 th:if="${#lists.isEmpty(transactions)}" class="mt-1 mb-1 center">No income or expenses<br>tracked so far this month.</h4>-->
+                <img th:if="${#lists.isEmpty(banks)}" th:src="@{/images/bank.png}" alt="bank institution" width="100px" style="margin: 0 auto; display: block;" class="mt-3"/>
+                <h4 th:if="${#lists.isEmpty(banks)}" class="mt-1 mb-1 center">Connect your bank account to track your actual income and expenses.</h4>
+
+                <div th:if="${banks != null and !#lists.isEmpty(banks)}" class="table-container">
+                    <div class="row pb-0">
+                        <div class="col-1"></div>
+                        <div class="col-3"><strong>Institution</strong></div>
+                        <div class="col-3"><strong>Subtype</strong></div>
+                        <div class="col-3"><strong>Available</strong></div>
+                        <div class="col-2"><strong>Current</strong></div>
+                    </div>
+                </div>
+                <div th:each="bank: ${banks}" class="table-container mb-3">
+                    <div class="row border-bottom border-dark border-1 pt-3">
+                        <div class="col-1 ps-0"><img th:src="@{/images/bank.png}" alt="bank institution" width="30px"></div>
+                        <div class="col-3"><span class="align-middle" th:text="${bank.institution}"></span></div>
+                        <div class="col-3"><span class="align-middle" th:text="${bank.subtype}"></span></div>
+                        <div class="col-3"><span class="align-middle">$</span><span class="align-middle" th:text="${bank.balanceAvailable}"></span></div>
+                        <div class="col-2"><span class="align-middle">$</span><span class="align-middle" th:text="${bank.balanceCurrent}"></span></div>
+                    </div>
+                </div>
+                <p th:if="${banks != null and !#lists.isEmpty(banks)}" class="mt-1 mb-1 center">Connect additional bank accounts<br>to track your income and expenses.</p>
+                <br>
+                <!-- Button to trigger Plaid link integration modal -->
+                <button id="link-button" type="button" class="btn btn-secondary block marginAuto">
+                    Link Account
+                </button>
+            </div>
         </div>
     </div>
     <!-- Transaction Modal -->


### PR DESCRIPTION
This PR introduces a new tab for "Banks" that connects to a Sandbox version of the Plaid API.

![image](https://github.com/user-attachments/assets/f0dde40e-3044-4f4c-bab6-0e260c71a1f6)


When clicking the Link Account button a plaid link dialog opens.
Complete the dialog with
user_good
pass_good
and MFA 1234
The page will reload and the bank account available and current balances will populate on the banks tab.
There's many limitations on how I implemented this integration - it's only looking at the plaid accounts balance get endpoint and the first account that comes back. We could refactor it to process multiple accounts for the same user later. Once one successful bank connection works subsequent attempt also will fail. So we'll steer away from those for the demo.
![image](https://github.com/user-attachments/assets/ab38feea-8f28-40c7-a63b-4aff9f6e08c5)
