### PR TITLE
Modify OverBudget

### DIFF
--- a/app/src/main/java/com/budget/app/controller/MainController.java
+++ b/app/src/main/java/com/budget/app/controller/MainController.java
@@ -173,8 +173,10 @@ public class MainController {
 			List<Double> plannedValues = new ArrayList<>();
 			List<Double> remainingValues = new ArrayList<>();
 
-			for (LineItem lineItem : filteredLineItems)
-			{
+			for (LineItem lineItem : filteredLineItems) {
+				if (lineItem.isIncome()) {
+					continue; // Skip income line items
+				}
 				double plannedAmount = lineItem.getPlannedAmount().doubleValue();
 
 				double totalAmount = 0;

--- a/app/src/main/resources/data.sql
+++ b/app/src/main/resources/data.sql
@@ -98,7 +98,7 @@ VALUES (6, FALSE, 'Rent Payment', 1500, 'MONTHLY');
 INSERT INTO line_items (category_id, is_income, line_item_name, planned_amount, recurrence)
 VALUES (7, FALSE, 'Water Bill', 50, 'MONTHLY');
 INSERT INTO line_items (category_id, is_income, line_item_name, planned_amount, recurrence)
-VALUES (8, FALSE, 'Grocery Delivery', 100, 'BI_WEEKLY');
+VALUES (8, TRUE, 'Employer LLC', 3700, 'MONTHLY');
 INSERT INTO line_items (category_id, is_income, line_item_name, planned_amount, recurrence)
 VALUES (9, FALSE, 'Uber Rides', 75, 'MONTHLY');
 INSERT INTO line_items (category_id, is_income, line_item_name, planned_amount, recurrence)
@@ -272,3 +272,6 @@ VALUES (7, '2025-04-05', 'Water', 'water bill', 48.00);
 
 INSERT INTO transactions (line_item_id, transaction_date, merchant, note, actual_amount)
 VALUES (10, '2025-04-07', 'Checkup', 'Annual Physical', 89.00);
+
+INSERT INTO transactions (line_item_id, transaction_date, merchant, note, actual_amount)
+VALUES (8, '2025-04-07', 'Paycheck', 'April Paycheck', 3824.00);

--- a/app/src/main/resources/templates/dashboardFragments.html
+++ b/app/src/main/resources/templates/dashboardFragments.html
@@ -37,7 +37,7 @@
                 <tr>
                     <th th:text="${category.getCategoryName()}"></th>
                     <th>Planned</th>
-                    <th>Spent</th>
+                    <th>Actual</th>
                     <th class="tableWidth">
                         <button type="button" class="btn btn-light btn-sm rounded-pill" data-bs-toggle="modal" data-bs-target="#addLineItemModal">
                             +
@@ -61,8 +61,8 @@
                                    class="form-control" min="0" step="any" th:id="|plannedAmountInput-${lineItem.id}|" style="display:none;"/>
                         </form>
                     </td>
-                    <td th:class="${lineItem.plannedAmount < lineItem.cumulativeActualAmount}?text-danger">
-                        <span th:text="${lineItem.plannedAmount < lineItem.cumulativeActualAmount}?'$'+${lineItem.cumulativeActualAmount}+' (over budget)':'$'+${lineItem.cumulativeActualAmount}"></span>
+                    <td th:class="${lineItem.isIncome} ? 'text-success' : (${lineItem.plannedAmount < lineItem.cumulativeActualAmount} ? 'text-danger' : '')">
+                        <span th:text="${lineItem.plannedAmount < lineItem.cumulativeActualAmount}?'$'+${lineItem.cumulativeActualAmount}:'$'+${lineItem.cumulativeActualAmount}"></span>
                     </td>
                     <td class="tableWidth">
                         <button type="button"
@@ -221,7 +221,7 @@
                         <div class="text-center">
                             <h5>Planned Amount</h5>
                             <ul class="list-group">
-                                <li th:each="lineItem : ${lineItems}" class="list-group-item">
+                                <li th:each="lineItem : ${lineItems}" th:if="${!lineItem.income}" class="list-group-item">
                                     <span th:text="${lineItem.lineItemName}">Item Name</span>
                                     <span th:text="'$'+${lineItem.plannedAmount}">Planned Amount</span>
 <!--                                    <span th:text="${transaction != null ? transaction.actualAmount : 'N/A'}">Amount</span>-->
@@ -237,7 +237,7 @@
                         <div class="text-center">
                             <h5>Spent</h5>
                             <ul class="list-group">
-                                <li th:each="lineItem : ${lineItems}" class="list-group-item">
+                                <li th:each="lineItem : ${lineItems}" th:if="${!lineItem.income}" class="list-group-item">
                                     <span th:text="${lineItem.lineItemName}">Item Name</span>
                                     <span th:text="'$'+${lineItem.cumulativeActualAmount}">Amount</span>
                                 </li>
@@ -252,9 +252,10 @@
                         <div class="text-center">
                             <h5>Remaining Amount</h5>
                             <ul class="list-group">
-                                <li th:each="lineItem : ${lineItems}" class="list-group-item">
+                                <li th:each="lineItem : ${lineItems}" th:if="${!lineItem.income}" class="list-group-item">
                                     <span th:text="${lineItem.lineItemName}">Item Name</span>
-                                    <span th:text="'$' + ${lineItem.plannedAmount - lineItem.cumulativeActualAmount}">Remaining Amount</span>
+                                    <span  th:class="${lineItem.plannedAmount - lineItem.cumulativeActualAmount < 0} ? 'text-danger' : ''"
+                                           th:text="'$' + (${lineItem.plannedAmount} - ${lineItem.cumulativeActualAmount})">Remaining Amount</span>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
Switched Spent back to Actual in the table since income is included 

make Actual text green when isIncome = true

change graph/list of transactions so that it doesnt include income in budget insights tab and the text turns red when the remaining is less that the planned amount. 

